### PR TITLE
changed gitmodule to use https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "chemprop_repo"]
 	path = chemprop_fitting/chemprop_repo
-	url = git@github.com:chemprop/chemprop.git
+	url = https://github.com/chemprop/chemprop.git


### PR DESCRIPTION
Hopefully resolving issue https://github.com/srensi/tmprss2/issues/5
I tested by cloning the repo into some other directory with this change by running
```git clone --recurse-submodules --single-branch --branch gitmodule_to_https https://github.com/srensi/tmprss2.git```
and it worked for me.  So seems like a purely https strategy works?